### PR TITLE
fix: clamp decay strength to [0, 1] to prevent values exceeding 1.0

### DIFF
--- a/src/services/decay.py
+++ b/src/services/decay.py
@@ -45,4 +45,4 @@ def compute_strength(
     effective_lambda = base_lambda * (1 - importance * 0.8)
     strength = importance * math.exp(-effective_lambda * days) * (1 + recall_count * 0.2)
 
-    return round(strength, 6)
+    return round(min(1.0, strength), 6)


### PR DESCRIPTION
## Summary
- `compute_strength()` in `src/services/decay.py` can return values > 1.0 due to the recall_count multiplier
- With `importance=1.0, days=0, recall_count=5`: strength = `1.0 * 1.0 * 2.0 = 2.0`
- This breaks the UI (percentage display assumes 0-100%), graph edge weights (capped at 1.0), and prune threshold logic (assumes 0-1 range)
- Added `min(1.0, ...)` clamp to ensure strength stays in the expected [0, 1] range

## Bug Details
The formula is: `strength = importance × e^(-effective_λ × days) × (1 + recall_count × 0.2)`
When `days` is small (recently accessed) and `recall_count` is high, the multiplier `(1 + recall_count * 0.2)` grows unbounded.

## Test plan
- [ ] Verify strength stays ≤ 1.0 for memories with high recall counts
- [ ] Verify normal decay behavior is unchanged (strength still decreases over time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)