### PR TITLE
fix: use deque for BFS traversal instead of list.pop(0)

### DIFF
--- a/src/graph/networkx_backend.py
+++ b/src/graph/networkx_backend.py
@@ -6,6 +6,7 @@ Graph is persisted as a pickle file at ~/.yourmemory/graph.pkl.
 import os
 import pickle
 import threading
+from collections import deque
 from pathlib import Path
 from typing import Optional
 
@@ -110,10 +111,10 @@ class NetworkXBackend(GraphBackend):
                 return []
 
             visited = {}  # memory_id → {"distance": int, "edge_weight": float}
-            queue = [(memory_id, 0, 1.0)]  # (node, depth, cumulative_weight)
+            queue = deque([(memory_id, 0, 1.0)])  # (node, depth, cumulative_weight)
 
             while queue:
-                node, depth, cum_weight = queue.pop(0)
+                node, depth, cum_weight = queue.popleft()
                 if depth > max_depth:
                     continue
 


### PR DESCRIPTION
## Summary
- `get_neighbors()` in `src/graph/networkx_backend.py` used `list.pop(0)` for BFS traversal
- `list.pop(0)` is O(n) because it shifts all remaining elements
- Replaced with `collections.deque` and `popleft()` for O(1) operations

## Bug Details
For large memory graphs with many nodes, the BFS traversal becomes unnecessarily slow since every `pop(0)` call shifts all remaining elements. With `deque.popleft()`, the operation is constant time.

## Test plan
- [ ] Verify `get_neighbors()` returns the same results as before
- [ ] Test with a graph containing 100+ nodes to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)