### PR TITLE
fix: remove redundant migrate() call in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,4 @@
 import uvicorn
-from src.db.migrate import migrate
 
 if __name__ == "__main__":
-    migrate()
     uvicorn.run("src.app:app", host="0.0.0.0", port=8000, reload=True)


### PR DESCRIPTION
## Summary
- `main.py` called `migrate()` directly before `uvicorn.run()`, but `src.app:app` already runs `migrate()` in its `lifespan` context manager
- This caused database migration to run twice on every startup
- Removed the redundant `migrate()` call from `main.py`, keeping the one in `src/app.py` lifespan as the single source of truth

## Bug Details
When `python main.py` is executed:
1. `main.py` line 5: `migrate()` runs immediately
2. `uvicorn.run("src.app:app", ...)` loads the module and triggers `lifespan()`, which calls `migrate()` again

This doubles startup time and creates a potential race condition if both migration calls execute concurrently (e.g., with `reload=True`).

## Test plan
- [ ] Verify `python main.py` still starts correctly and tables are created
- [ ] Verify migration only appears once in startup logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)