### PR TITLE
fix: add thread-safe lazy initialization for SentenceTransformer

### DIFF
--- a/src/services/embed.py
+++ b/src/services/embed.py
@@ -1,12 +1,17 @@
+import threading
+
 from sentence_transformers import SentenceTransformer
 
 _model: SentenceTransformer | None = None
+_lock = threading.Lock()
 
 
 def _get_model() -> SentenceTransformer:
     global _model
     if _model is None:
-        _model = SentenceTransformer("all-mpnet-base-v2")
+        with _lock:
+            if _model is None:
+                _model = SentenceTransformer("all-mpnet-base-v2")
     return _model
 
 


### PR DESCRIPTION
## Summary
- `src/services/embed.py` used a check-then-set pattern without any locking for the global `_model` variable
- In SSE mode (uvicorn with multiple workers/threads), concurrent requests could simultaneously create multiple SentenceTransformer instances (~2GB RAM each)
- Added double-checked locking with `threading.Lock` to ensure only one model instance is created

## Bug Details
The original code:
```python
_model = None
def _get_model():
    global _model
    if _model is None:
        _model = SentenceTransformer("all-mpnet-base-v2")  # ~2GB, slow
    return _model
```

If two requests arrive before the first model finishes loading (~10s for first load), both threads enter the `if _model is None` branch, loading the model twice and potentially causing a race condition on the global variable assignment.

## Test plan
- [ ] Verify embedding still works: `from src.services.embed import embed; embed("test")`
- [ ] Verify no regression in single-threaded mode
- [ ] Confirm only one SentenceTransformer instance is created under concurrent access

🤖 Generated with [Claude Code](https://claude.com/claude-code)