### PR TITLE
fix: use INSERT OR REPLACE for SQLite FTS backfill

### DIFF
--- a/src/db/migrate.py
+++ b/src/db/migrate.py
@@ -39,9 +39,9 @@ def migrate():
     # ── Post-schema FTS setup ─────────────────────────────────────────────
     if backend == "sqlite":
         # Backfill any rows that existed before the FTS table was created.
-        # The INSERT OR IGNORE prevents double-indexing on a fresh DB.
+        # Use INSERT OR REPLACE so updated content is re-indexed.
         conn.executescript("""
-            INSERT OR IGNORE INTO memories_fts(rowid, content)
+            INSERT OR REPLACE INTO memories_fts(rowid, content)
             SELECT id, content FROM memories;
         """)
 


### PR DESCRIPTION
## Summary
- SQLite FTS backfill in `src/db/migrate.py` used `INSERT OR IGNORE` which skips existing rowids
- If a memory's content was updated (via `update_memory`) but the FTS index was not refreshed, the stale entry would never be corrected
- Changed to `INSERT OR REPLACE` so existing FTS entries are updated with current content on every migration run

## Bug Details
When `update_memory` modifies a memory's content, the FTS index for that row is not updated. The migration backfill runs `INSERT OR IGNORE` which only inserts new rows — it silently skips rows that already exist in `memories_fts`, leaving stale text in the search index. This causes keyword searches to return outdated content snippets.

`INSERT OR REPLACE` replaces the FTS entry if it already exists, ensuring the search index always reflects the current content.

## Test plan
- [ ] Store a memory, update its content, run migration, and verify FTS search returns the updated content
- [ ] Verify fresh database setup still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)